### PR TITLE
Make Triumph a 0 for mixed usage

### DIFF
--- a/faces.txt
+++ b/faces.txt
@@ -87,7 +87,7 @@ persevere: -2
 % `cry` receives an AFINN score of `-1`, `crying`
 % receives `-2`. As the emoji is arguably in the middle
 % of crying, `cry` receives `crying`s `-2`.
-cry: -2
+% cry: -2
 
 % `joy` receives an AFINN score of `3`.
 joy: 3
@@ -138,8 +138,11 @@ angry: -3
 % due to its exaggerated expression by vendors, a `-4`.
 rage: -4
 
-% `triumph` receives an AFINN score of `4`.
-triumph: 4
+% `triumph` receives an AFINN score of `4`. However,
+% it can be seen as angry and is sometimes just
+% called 'face with stream from nose', so it 
+% is given an average of `0`
+triumph: 0
 
 % On the verge of tears[2]. Therefore, equal to `cry`.
 confounded: -2

--- a/faces.txt
+++ b/faces.txt
@@ -87,7 +87,7 @@ persevere: -2
 % `cry` receives an AFINN score of `-1`, `crying`
 % receives `-2`. As the emoji is arguably in the middle
 % of crying, `cry` receives `crying`s `-2`.
-% cry: -2
+cry: -2
 
 % `joy` receives an AFINN score of `3`.
 joy: 3


### PR DESCRIPTION
Note that unicode calls it a negative face, 'face with steam coming from nose' 
http://unicode.org/emoji/charts/full-emoji-list.html#1f624

Thus, it should probably be zero because the very negative cancels out the very positive use cases.
I tried to match your commenting style.